### PR TITLE
Fix for same name methods

### DIFF
--- a/templates/apidoc/apidoc.js
+++ b/templates/apidoc/apidoc.js
@@ -1,6 +1,6 @@
 /**
  * @api {{{method}}} {{url}} {{api_name}}
- * @apiName {{api_name}}
+ * @apiName {{method}}/{{api_name}}
  * @apiGroup {{api_group}}
  * @apiDescription {{api_description}}
  *


### PR DESCRIPTION
If there are methods with same name, configuration that is generated for apidoc will generate multiple attributes with same apiName. This will result in generated documentation with only one method.

Fix is consisted of prepending the name with method. This will generate unique calls for different methods.